### PR TITLE
Fix long file names causing upload failures for the entire upload batch during migration

### DIFF
--- a/.github/workflows/build-s3-migration.yaml
+++ b/.github/workflows/build-s3-migration.yaml
@@ -142,7 +142,7 @@ jobs:
 
   build-macos:
     name: Build-macos
-    runs-on: macos-runner-binary
+    runs-on: macos-latest
     steps:
       - name: Setup go 1.18
         uses: actions/setup-go@v2

--- a/.github/workflows/build-s3-migration.yaml
+++ b/.github/workflows/build-s3-migration.yaml
@@ -114,7 +114,7 @@ jobs:
           } ElseIf ( "${{github.base_ref}}" -eq "staging" -OR "${{github.ref}}" -eq "refs/heads/staging" ){
             echo "TAG=v0.0.0-staging" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           } ELSE {
-            echo "TAG=${{github.ref}}" | %{$_ -replace('refs/tags/', '')} | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+            echo "TAG=v0.0.0-${{github.base_ref}}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           }
 
       - name: Install

--- a/.github/workflows/build-s3-migration.yaml
+++ b/.github/workflows/build-s3-migration.yaml
@@ -142,7 +142,7 @@ jobs:
 
   build-macos:
     name: Build-macos
-    runs-on: macos-latest
+    runs-on: macos-runner-binary
     steps:
       - name: Setup go 1.18
         uses: actions/setup-go@v2

--- a/.github/workflows/build-s3-migration.yaml
+++ b/.github/workflows/build-s3-migration.yaml
@@ -42,7 +42,7 @@ jobs:
           elif  [[ "${{github.base_ref}}" == "staging" || "${{github.ref}}" == "refs/heads/staging" ]]; then
             echo "TAG=v0.0.0-staging" >> $GITHUB_ENV
           else
-            echo "TAG=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_ENV
+            echo "TAG=v0.0.0-${{github.base_ref}}" >> $GITHUB_ENV
           fi
 
       - name: add dependencies

--- a/.github/workflows/build-s3-migration.yaml
+++ b/.github/workflows/build-s3-migration.yaml
@@ -161,7 +161,7 @@ jobs:
           elif  [[ "${{github.base_ref}}" == "staging" || "${{github.ref}}" == "refs/heads/staging" ]]; then
             echo "TAG=v0.0.0-staging" >> $GITHUB_ENV
           else
-            echo "TAG=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_ENV
+            echo "TAG=v0.0.0-${{github.base_ref}}" >> $GITHUB_ENV
           fi
       - name: Install
         run: make build

--- a/migration/migrate.go
+++ b/migration/migrate.go
@@ -393,7 +393,7 @@ func getShortObjectKey(objectKey string) string {
 	const maxLength = 90
 
 	if len(objectKey) > maxLength {
-		//get the last 100 characters of the object key.
+		//get the last maxLength characters of the object key.
 		shortKey := objectKey[len(objectKey)-maxLength:]
 		return shortKey
 	}


### PR DESCRIPTION
Fixing the long file names which cause errors during migration by trimming the long file names to 90 chars.