### PR TITLE
Fix misbehaving error worker

### DIFF
--- a/migration/migrate.go
+++ b/migration/migrate.go
@@ -22,7 +22,7 @@ import (
 
 const Batch = 10
 const (
-	Replace   = iota //Will replace existing file
+	Replace   = iota // Will replace existing file
 	Skip             // Will skip migration if file already exists
 	Duplicate        // Will add _copy prefix and uploads the file
 )
@@ -62,10 +62,10 @@ type Migration struct {
 	skip       int
 	retryCount int
 
-	//Number of goroutines to run. So at most concurrency * Batch goroutines will run. i.e. for bucket level and object level
+	// Number of goroutines to run. So at most concurrency * Batch goroutines will run. i.e. for bucket level and object level
 	concurrency int
 
-	szCtMu               sync.Mutex //size and count mutex; used to update migratedSize and totalMigratedObjects
+	szCtMu               sync.Mutex // size and count mutex; used to update migratedSize and totalMigratedObjects
 	migratedSize         uint64
 	totalMigratedObjects uint64
 
@@ -235,8 +235,16 @@ func StartMigration() error {
 	}
 
 	migrationWorker := NewMigrationWorker(migration.workDir)
-	go migration.DownloadWorker(rootContext, migrationWorker)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		migration.DownloadWorker(rootContext, migrationWorker)
+	}()
 	// go migration.UploadWorker(rootContext, migrationWorker)
+	wg.Wait()
+
 	migration.UpdateStateFile(migrationWorker)
 	err := migrationWorker.GetMigrationError()
 	if err != nil {
@@ -563,7 +571,7 @@ func (m *Migration) processMultiOperation(ctx context.Context, ops []MigrationOp
 	})
 	for _, op := range ops {
 		migrator.UploadDone(op.uploadObj, err)
-		zlogger.Logger.Info("upload done: ", op.uploadObj.ObjectKey, "size ", op.uploadObj.Size, err)
+		zlogger.Logger.Info("upload done: ", op.uploadObj.ObjectKey, " size ", op.uploadObj.Size, err)
 	}
 	migrator.SetMigrationError(err)
 	return err


### PR DESCRIPTION
closes #90 
Currently sometimes the error worker do not report the failure in migration and instead it returns a "migration successful" message even for the cases where the migration should have failed. Fixing this by waiting for the DownloadWorker goroutine to finish before returning from migrate cmd. 